### PR TITLE
prevent AI from devpushing/devving when at war

### DIFF
--- a/events/ManaEvents.txt
+++ b/events/ManaEvents.txt
@@ -7,7 +7,8 @@ country_event = {
 	hidden = yes
 
 	trigger = {
-        ai = yes
+		ai = yes
+		is_at_war = no
 		OR = {
 			AND = {
 				primitives = no


### PR DESCRIPTION
AI sometimes devs provinces which they lose in the war they find themselves at that moment.

To prevent accidently devpushing for the enemy, only dev when not at war.
(See issue #2 )