### PR TITLE
fix rebel spam when revoking estate land

### DIFF
--- a/common/estate_crown_land/00_interactions.txt
+++ b/common/estate_crown_land/00_interactions.txt
@@ -311,7 +311,7 @@ interaction = {
 		}
 	}
 	ai_will_do = {
-		factor = 50
+		factor = 100
 		modifier = {
 			factor = 0
 			crown_land_share = 30
@@ -481,29 +481,16 @@ interaction = {
 			}
 		}
 		modifier = {
-			factor = 0.5
-			NOT = {
-				estate_loyalty = {
-					estate = all
-					loyalty = 50
+			factor = 0
+			AND = {
+				ROOT = {
+					government = theocracy
 				}
-			}
-		}
-		modifier = {
-			factor = 0.5
-			NOT = {
-				estate_loyalty = {
-					estate = all
-					loyalty = 40
-				}
-			}
-		}
-		modifier = {
-			factor = 0.5
-			NOT = {
-				estate_loyalty = {
-					estate = all
-					loyalty = 35 # Estate is almost disloyal
+				NOT = {
+					estate_loyalty = {
+						estate = estate_church
+						loyalty = 60
+					}
 				}
 			}
 		}
@@ -512,7 +499,7 @@ interaction = {
 			NOT = {
 				estate_loyalty = {
 					estate = all
-					loyalty = 30 # Estate is basically disloyal
+					loyalty = 50
 				}
 			}
 		}


### PR DESCRIPTION
raise loyalty requirements overall to 50 (due to -20 when revoking) + raise requirements for estate_church to 60 when government = theocracy (or any subset of it)